### PR TITLE
Create no-op module for production within this project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 .idea/
+*/build

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ allprojects {
 In your application's `build.gradle` file, add a dependency for Android DebugPort:
 
 ```groovy
-debugCompile 'com.github.jasonwyatt:Android-DebugPort:1.1.0'
-releaseCompile 'com.github.jasonwyatt:Android-DebugPort-NOOP:1.1.0'
+debugCompile 'com.github.jasonwyatt:Android-DebugPort:library:1.1.0'
+releaseCompile 'com.github.jasonwyatt:Android-DebugPort:library-noop:1.1.0'
 ```
 
 **Note:** The final line above will use a [no-op version of the DebugPort library](https://github.com/jasonwyatt/Android-DebugPort-NOOP) in production builds. This makes it impossible for people to run the DebugPort server on a production build.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    debugCompile project(':library-noop')
-    testCompile project(':library-noop')
+
+    debugCompile project(':library')
     releaseCompile project(':library-noop')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    debugCompile project(':library')
-    testCompile project(':library')
-    releaseCompile 'com.github.jasonwyatt:Android-DebugPort-NOOP:0.3.1'
+    debugCompile project(':library-noop')
+    testCompile project(':library-noop')
+    releaseCompile project(':library-noop')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="jwf.debugport.app">
 
+    <!--
+    Only used when running in `release` variant, for the code that displays the current ip..
+    not needed for your app, unless you also wish to access wifi state.
+    -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/library-noop/build.gradle
+++ b/library-noop/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName "2.0.0"
     }
 }
 

--- a/library-noop/build.gradle
+++ b/library-noop/build.gradle
@@ -5,19 +5,20 @@ group='com.github.jasonwyatt'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
-        versionCode 2
-        versionName "1.1.0"
+        versionCode 1
+        versionName "1.0"
     }
 }
 
 dependencies {
-    compile "org.apache-extras.beanshell:bsh:2.0b6"
-    compile "com.android.support:support-compat:25.3.1"
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    testCompile 'junit:junit:4.12'
+    compile "com.android.support:support-annotations:25.3.1"
 }
 
 // build a jar with source files

--- a/library-noop/proguard-rules.pro
+++ b/library-noop/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /Users/jason/Library/Android/sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# Add any project specific keep options here:
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/library-noop/src/main/AndroidManifest.xml
+++ b/library-noop/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="jwf.debugport" />

--- a/library-noop/src/main/java/jwf/debugport/DebugPortService.java
+++ b/library-noop/src/main/java/jwf/debugport/DebugPortService.java
@@ -1,0 +1,37 @@
+package jwf.debugport;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * No-op implementation of DebugPortService.
+ */
+public class DebugPortService extends Service {
+    public static final String METADATA_DEBUG_PORT = "jwf.debugport.METADATA_DEBUG_PORT";
+    public static final String METADATA_SQLITE_PORT = "jwf.debugport.METADATA_SQLITE_PORT";
+    public static final String METADATA_STARTUP_COMMANDS = "jwf.debugport.METADATA_STARTUP_COMMANDS";
+
+    public static Params start(Context context) {
+        Params params = new Params();
+        return params;
+    }
+
+    public static void start(Context context, @NonNull Params params) {
+    }
+
+    public static void stop(Context context) {
+    }
+
+    public static void kill(Context context) {
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+}

--- a/library-noop/src/main/java/jwf/debugport/Params.java
+++ b/library-noop/src/main/java/jwf/debugport/Params.java
@@ -1,0 +1,94 @@
+package jwf.debugport;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
+
+/**
+ * Duplicate of Params class for no-op production usage.
+ */
+public class Params implements Parcelable {
+    public static final int DEFAULT_ANDROID_PORT = -1;
+    public static final int DEFAULT_SQLITE_PORT = -1;
+    private int mDebugPort;
+    private int mSQLitePort;
+    private String[] mStartupCommands;
+
+    public Params() {
+        mDebugPort = DEFAULT_ANDROID_PORT;
+        mSQLitePort = DEFAULT_SQLITE_PORT;
+        mStartupCommands = new String[0];
+    }
+
+    @Deprecated
+    public Params setPort(int port) {
+        return this;
+    }
+
+    @Deprecated
+    public int getPort() {
+        return mDebugPort;
+    }
+
+    public Params setDebugPort(int port) {
+        return this;
+    }
+
+    public int getDebugPort() {
+        return mDebugPort;
+    }
+
+    public Params setSQLitePort(int port) {
+        return this;
+    }
+
+    public int getSQLitePort() {
+        return mSQLitePort;
+    }
+
+    public Params setStartupCommands(@Nullable String[] commands) {
+        return this;
+    }
+
+    public String[] getStartupCommands() {
+        return mStartupCommands;
+    }
+
+    @Override
+    public int describeContents() {
+        return hashCode();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(mDebugPort);
+        dest.writeInt(mSQLitePort);
+        dest.writeInt(mStartupCommands.length);
+        dest.writeStringArray(mStartupCommands);
+    }
+
+    @Override
+    public String toString() {
+        return "No-Op Params<>";
+    }
+
+    public static final Creator<Params> CREATOR = new Creator<Params>() {
+        @Override
+        public Params createFromParcel(Parcel source) {
+            Params p = new Params();
+            p.setDebugPort(source.readInt());
+            p.setSQLitePort(source.readInt());
+
+            int startupCommandsLength = source.readInt();
+            String[] startupCommands = new String[startupCommandsLength];
+            source.readStringArray(startupCommands);
+            p.setStartupCommands(startupCommands);
+            return p;
+        }
+
+        @Override
+        public Params[] newArray(int size) {
+            return new Params[size];
+        }
+    };
+}

--- a/library-noop/src/main/res/values/strings.xml
+++ b/library-noop/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Android DebugPort No-op</string>
-</resources>

--- a/library-noop/src/main/res/values/strings.xml
+++ b/library-noop/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android DebugPort No-op</string>
+</resources>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 25
-        versionCode 2
-        versionName "1.1.0"
+        versionCode 3
+        versionName "2.0.0"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':library'
+include ':app', ':library', ':library-noop'


### PR DESCRIPTION
Previously, the no-op library was defined in a [separate Github repository](https://github.com/jasonwyatt/Android-DebugPort-NOOP).  This branch moves that module within the main project.